### PR TITLE
songdetails setup.py does not include the mp3details module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     description="Song details retrieval package.",
     long_description="Retrieves Song detail information such as artist, title, album duration, etc.",
     license="FreeBSD",
-    packages=["songdetails"],
+    packages=['songdetails', 'songdetails.mp3details'],
     package_dir={'songdetails': 'src/songdetails'}
 )


### PR DESCRIPTION
setup.py must explicitly define all packages that need to be installed. This patch provides that fix to setup.py. 
http://docs.python.org/distutils/setupscript.html (section 2.1) 

Or am I'm being a total python n00b and shooting myself in the foot here?
